### PR TITLE
Added a flushPending method to the wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ angular.module('myApp').controller('testCtrl', function (debounce) {
     // Want to stop waiting and send out the call immediately? Flush it!
     fn.flush();
 
+    // Want to stop waiting and send out the call immedialtely if any was made? Flush pending calls!
+    fn.flushPending();
+
     // No longer care about it? Cancel is supported.
     fn.cancel();
 });

--- a/src/debounce.js
+++ b/src/debounce.js
@@ -32,10 +32,7 @@ angular.module('rt.debounce', []).factory('debounce', function ($timeout) {
             var pending = !!context;
             if (pending) {
                 // Call pending, do it now.
-<<<<<<< HEAD
                 cancel();
-=======
->>>>>>> dc0499f337d9099124b9765de3007e13462892b7
                 ping();
             }
             return pending;

--- a/src/debounce.js
+++ b/src/debounce.js
@@ -2,7 +2,7 @@ angular.module('rt.debounce', []).factory('debounce', function ($timeout) {
 
     return function (wait, fn) {
         var args, context, result, timeout;
-
+        
         // Execute the callback function
         function ping() {
             result = fn.apply(context || this, args || []);
@@ -26,6 +26,17 @@ angular.module('rt.debounce', []).factory('debounce', function ($timeout) {
             cancel();
             timeout = $timeout(ping, wait);
         }
+        
+        // Forces the execution of pending calls
+        function flushPending() {
+            var pending = !!context;
+            if (pending) {
+                // Call pending, do it now.
+                cancel();
+                ping();
+            }
+            return pending;
+        }
 
         // The wrapper also has a flush method, which you can use to
         // force the execution of the last scheduled call to happen
@@ -33,14 +44,16 @@ angular.module('rt.debounce', []).factory('debounce', function ($timeout) {
         // call. Note that for asynchronous operations, you'll need to
         // return a promise and wait for that one to resolve.
         wrapper.flush = function () {
-            if (context) {
-                // Call pending, do it now.
-                cancel();
-                ping();
-            } else if (!timeout) {
+            if (!flushPending() && !timeout) {
                 // Never been called.
                 ping();
             }
+            return result;
+        };
+        
+        // Flushes pending calls if any
+        wrapper.flushPending = function () {
+            flushPending();
             return result;
         };
         

--- a/test/debounce.js
+++ b/test/debounce.js
@@ -84,4 +84,23 @@ describe('Debounce', function () {
         $timeout.flush(100);
         assert.equal(calls, 0);
     });
+    
+    it('Does not execute the callback if no calls were made when calling flushPending', function () {
+        assert.equal(calls, 0);
+        fn.flushPending();
+        assert.equal(calls, 0);
+    });
+    
+    it('Flushes pending calls when calling flushPending', function () {
+        assert.equal(calls, 0);
+        fn();
+        fn.flushPending();
+        assert.equal(calls, 1);
+    });
+
+    it('Returns the result of a flushPending call', function () {
+        fn();
+        var result = fn.flushPending();
+        assert.equal(result, 1);
+    });
 });


### PR DESCRIPTION
Hi,
I was a little surprised discovering that flush calls the underlying method even if the wrapper never was called, but since this scenario is covered with a test I figured that this is wanted behaviour. So to allow only flushing pending calls I added a separate method "flushPending" to the wrapper. Hope this makes sense to you.

Regards
Jakob